### PR TITLE
Add SDL2 desktop port

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ The application exposes its file storage as a USB mass storage device and also o
    idf.py -p /dev/ttyUSB0 flash monitor
    ```
 
+### Desktop Build
+To build a simplified player that runs on a PC you need SDL2 installed.
+Run the following commands:
+```bash
+mkdir build-desktop && cd build-desktop
+cmake ../desktop
+make
+./fami32_desktop <your_module.ftm>
+```
+
 ## Usage
 Upon reset the device mounts the internal FAT partition as `/flash` and exposes it over USB. Copy FTM modules to this storage to load them from the file menu. A configuration file is stored at `/flash/FM32CONF.CNF` and contains settings such as sample rate, engine speed and filter cut‑offs.
 

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.10)
+project(Fami32Desktop)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(SDL2 REQUIRED)
+include_directories(${SDL2_INCLUDE_DIRS}
+                    ../main/include
+                    ../main/include/fami32core)
+
+add_definitions(-DDESKTOP_BUILD)
+
+set(SRC
+    ../main/fami32core/fami32_channel.cpp
+    ../main/fami32core/fami32_instrument.cpp
+    ../main/fami32core/fami32_player.cpp
+    ../main/ftm_file.cpp
+    ../main/dpcm.c
+    ../main/note2freq.c
+    ../main/wave_table.c
+    ../main/micro_config.c
+    ../main/src_config.c
+    ../main/gen_env.cpp
+    main.cpp
+)
+
+add_executable(fami32_desktop ${SRC})
+target_link_libraries(fami32_desktop SDL2::SDL2 SDL2::SDL2main)

--- a/desktop/main.cpp
+++ b/desktop/main.cpp
@@ -1,0 +1,72 @@
+#include <SDL2/SDL.h>
+#include "ftm_file.h"
+#include "fami32_player.h"
+
+bool _debug_print = false;
+bool _midi_output = false;
+bool edit_mode = false;
+int g_vol = 16;
+
+FAMI_PLAYER player;
+
+static void audio_callback(void* userdata, Uint8* stream, int len) {
+    int16_t* out = reinterpret_cast<int16_t*>(stream);
+    int samples = len / sizeof(int16_t);
+    while (samples > 0) {
+        player.process_tick();
+        int to_copy = player.get_buf_size();
+        if (to_copy > samples) to_copy = samples;
+        memcpy(out, player.get_buf(), to_copy * sizeof(int16_t));
+        out += to_copy;
+        samples -= to_copy;
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        printf("Usage: %s <module.ftm>\n", argv[0]);
+        return 1;
+    }
+
+    if (ftm.open_ftm(argv[1]) || ftm.read_ftm_all()) {
+        fprintf(stderr, "Failed to load %s\n", argv[1]);
+        return 1;
+    }
+
+    player.init(&ftm);
+    player.start_play();
+
+    if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO) < 0) {
+        fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    SDL_Window* win = SDL_CreateWindow("Fami32 Desktop", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, 0);
+    SDL_AudioSpec want{}, have{};
+    want.freq = SAMP_RATE;
+    want.format = AUDIO_S16SYS;
+    want.channels = 1;
+    want.samples = player.get_buf_size();
+    want.callback = audio_callback;
+    SDL_AudioDeviceID dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+    if (!dev) {
+        fprintf(stderr, "SDL audio error: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    SDL_PauseAudioDevice(dev, 0);
+
+    bool running = true;
+    while (running) {
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_QUIT) running = false;
+        }
+        SDL_Delay(10);
+    }
+
+    SDL_CloseAudioDevice(dev);
+    SDL_DestroyWindow(win);
+    SDL_Quit();
+    return 0;
+}

--- a/main/fami32core/fami32_player.cpp
+++ b/main/fami32core/fami32_player.cpp
@@ -212,30 +212,40 @@ void FAMI_PLAYER::process_item(unpk_item_t item, int c) {
     if (item.note != NO_NOTE) {
         if (item.note == NOTE_END) {
             channel[c].note_end();
+#ifndef DESKTOP_BUILD
             if (_midi_output && !mute[c]) {
                 MIDI.noteOff(channel[c].base_note, 0, c);
             }
+#endif
         } else if (item.note == NOTE_CUT) {
             channel[c].note_cut();
+#ifndef DESKTOP_BUILD
             if (_midi_output && !mute[c]) {
                 MIDI.noteOff(channel[c].base_note, 0, c);
             }
+#endif
         } else {
+#ifndef DESKTOP_BUILD
             if (_midi_output && !mute[c]) {
                 MIDI.noteOff(channel[c].base_note, 0, c);
             }
+#endif
             channel[c].set_note(item2note(item.note, item.octave));
             channel[c].note_start();
+#ifndef DESKTOP_BUILD
             if (_midi_output && !mute[c]) {
                 MIDI.noteOn(channel[c].base_note, (item.volume == NO_VOL ? channel[c].get_vol() : item.volume) << 3, c);
             }
+#endif
         }
     }
     if (item.volume != NO_VOL) {
         channel[c].set_vol(item.volume);
+#ifndef DESKTOP_BUILD
         if (_midi_output && !mute[c]) {
             MIDI.controlChange(7, item.volume << 3, c);
         }
+#endif
         // DBG_PRINTF("SET_VOL(C%d): %d\n", c, channel[c].get_vol());
     }
     process_efx_post(item.fxdata, c);

--- a/main/include/fami32core/fami32_common.h
+++ b/main/include/fami32core/fami32_common.h
@@ -7,7 +7,9 @@
 
 #include "ftm_file.h"
 #include "basic_dsp.h"
+#ifndef DESKTOP_BUILD
 #include <USBMIDI.h>
+#endif
 
 extern "C" {
 #include "src_config.h"
@@ -18,7 +20,9 @@ extern "C" {
 extern bool _debug_print;
 extern bool _midi_output;
 
+#ifndef DESKTOP_BUILD
 extern USBMIDI MIDI;
+#endif
 
 #define VOL_SEQU 0
 #define ARP_SEQU 1

--- a/main/src_config.c
+++ b/main/src_config.c
@@ -5,4 +5,8 @@ int ENG_SPEED = 60;
 int LPF_CUTOFF = 18000;
 int HPF_CUTOFF = 32;
 int OVER_SAMPLE = 4;
+#ifdef DESKTOP_BUILD
+const char *config_path = "FM32CONF.CNF";
+#else
 const char *config_path = "/flash/FM32CONF.CNF";
+#endif


### PR DESCRIPTION
## Summary
- allow building a simplified desktop version
- disable USB MIDI when building for desktop
- default config path adjusted for PC
- document desktop build steps

## Testing
- `cmake ../desktop`
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_683ff10ea0208328b640798c70e62b34