### PR TITLE
refactor: replace Adafruit keypad with ESP-IDF KeypadIO driver

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(SRCS "main.cpp" "dpcm.c" "ftm_file.cpp" "micro_config.c" "boot_check.cpp" "note2freq.c" "src_config.c" "wave_table.c" "gen_env.cpp"
                             "touch_input.cpp"
+                            "keypad_io.cpp"
                             "mpr121_keypad.cpp"
                             "usb_msc_mode.cpp" "uac_mode.cpp" "tinyusb_helper.cpp" "boot_router.cpp"
                             "gui/gui_common.cpp"
@@ -24,7 +25,7 @@ idf_component_register(SRCS "main.cpp" "dpcm.c" "ftm_file.cpp" "micro_config.c" 
 
                     PRIV_REQUIRES spi_flash
                     INCLUDE_DIRS "include" "include/gui" "include/fami32core"
-                    REQUIRES gfx_ssd1306 Adafruit_Keypad arduino-esp32-lite bt nvs_flash USBMIDI espcoredump esp_tinyusb)
+                    REQUIRES gfx_ssd1306 bt nvs_flash USBMIDI espcoredump esp_tinyusb)
 
 if(GIT_FOUND)
     execute_process(

--- a/main/boot_check.cpp
+++ b/main/boot_check.cpp
@@ -51,7 +51,7 @@ const char* get_exc_cause_name(uint32_t exc_cause) {
     }
 }
 
-void show_check_info(GfxOledSSD1306 *display, Adafruit_Keypad *keypad) {
+void show_check_info(GfxOledSSD1306 *display, KeypadIO *keypad) {
     display->setFont(&rismol57);
     display->fillRect(0, 0, 128, 9, 1);
     display->setTextColor(0);

--- a/main/boot_check.h
+++ b/main/boot_check.h
@@ -4,10 +4,10 @@
 #include "esp_core_dump.h"
 #include "esp_system.h"
 #include <gfx_oled_ssd1306.h>
-#include <Adafruit_Keypad.h>
+#include "keypad_io.h"
 
 const char* get_exc_cause_name(uint32_t exc_cause);
-void show_check_info(GfxOledSSD1306 *display, Adafruit_Keypad *keypad);
+void show_check_info(GfxOledSSD1306 *display, KeypadIO *keypad);
 int boot_check();
 
 #endif

--- a/main/include/MPR121_Keypad.h
+++ b/main/include/MPR121_Keypad.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <Adafruit_Keypad.h>
+#include "keypad_io.h"
 
 #define BUFFER_SIZE 16
 

--- a/main/include/gui/gui_common.h
+++ b/main/include/gui/gui_common.h
@@ -13,7 +13,7 @@
 #include <esp_system.h>
 #include <driver/i2s_std.h>
 #include <gfx_oled_ssd1306.h>
-#include <Adafruit_Keypad.h>
+#include "keypad_io.h"
 #include <MPR121_Keypad.h>
 #include <USBMIDI.h>
 #include "ringbuf.h"
@@ -34,7 +34,7 @@ extern "C" {
 
 extern FAMI_PLAYER player;
 extern GfxOledSSD1306 display;
-extern Adafruit_Keypad keypad;
+extern KeypadIO keypad;
 
 extern i2s_chan_handle_t i2s_tx_handle;
 

--- a/main/include/keypad_io.h
+++ b/main/include/keypad_io.h
@@ -1,0 +1,62 @@
+#ifndef KEYPAD_IO_H
+#define KEYPAD_IO_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define KEY_JUST_RELEASED (0)
+#define KEY_JUST_PRESSED (1)
+
+union keypadEvent {
+    struct {
+        uint8_t KEY;
+        uint8_t EVENT;
+        uint8_t ROW;
+        uint8_t COL;
+    } bit;
+    uint32_t reg;
+};
+
+class KeypadIO {
+public:
+    KeypadIO(const uint8_t *keymap,
+             const uint8_t *rowPins,
+             const uint8_t *colPins,
+             size_t numRows,
+             size_t numCols);
+
+    bool begin();
+    void tick();
+
+    bool justPressed(uint8_t key, bool clear = true);
+    bool justReleased(uint8_t key);
+    bool isPressed(uint8_t key) const;
+    bool isReleased(uint8_t key) const;
+
+    int available() const;
+    keypadEvent read();
+    void clear();
+
+private:
+    void pushEvent(const keypadEvent &event);
+    int findKeyIndex(uint8_t key) const;
+
+    const uint8_t *keymap_;
+    const uint8_t *rowPins_;
+    const uint8_t *colPins_;
+    size_t numRows_;
+    size_t numCols_;
+
+    static constexpr size_t BUFFER_SIZE = 32;
+    keypadEvent buffer_[BUFFER_SIZE];
+    size_t head_;
+    size_t tail_;
+    size_t count_;
+
+    static constexpr uint8_t STATE_PRESSED = (1U << 0);
+    static constexpr uint8_t STATE_JUST_PRESSED = (1U << 1);
+    static constexpr uint8_t STATE_JUST_RELEASED = (1U << 2);
+    uint8_t keyStates_[32];
+};
+
+#endif // KEYPAD_IO_H

--- a/main/keypad_io.cpp
+++ b/main/keypad_io.cpp
@@ -1,0 +1,189 @@
+#include "keypad_io.h"
+
+#include <cstring>
+
+#include "driver/gpio.h"
+#include "esp_log.h"
+#include "esp_rom_sys.h"
+
+namespace {
+constexpr const char *TAG = "KeypadIO";
+constexpr uint32_t SETTLING_DELAY_US = 20;
+} // namespace
+
+KeypadIO::KeypadIO(const uint8_t *keymap,
+                   const uint8_t *rowPins,
+                   const uint8_t *colPins,
+                   size_t numRows,
+                   size_t numCols)
+    : keymap_(keymap),
+      rowPins_(rowPins),
+      colPins_(colPins),
+      numRows_(numRows),
+      numCols_(numCols),
+      head_(0),
+      tail_(0),
+      count_(0) {
+    memset(keyStates_, 0, sizeof(keyStates_));
+}
+
+bool KeypadIO::begin() {
+    if (keymap_ == nullptr || rowPins_ == nullptr || colPins_ == nullptr || numRows_ == 0 || numCols_ == 0) {
+        ESP_LOGE(TAG, "invalid keypad config");
+        return false;
+    }
+
+    if ((numRows_ * numCols_) > sizeof(keyStates_)) {
+        ESP_LOGE(TAG, "too many keys: %u", static_cast<unsigned>(numRows_ * numCols_));
+        return false;
+    }
+
+    clear();
+
+    for (size_t i = 0; i < numCols_; ++i) {
+        gpio_config_t colCfg = {};
+        colCfg.pin_bit_mask = (1ULL << colPins_[i]);
+        colCfg.mode = GPIO_MODE_OUTPUT;
+        colCfg.pull_up_en = GPIO_PULLUP_DISABLE;
+        colCfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+        colCfg.intr_type = GPIO_INTR_DISABLE;
+        esp_err_t err = gpio_config(&colCfg);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to config col pin %u: %s", static_cast<unsigned>(colPins_[i]), esp_err_to_name(err));
+            return false;
+        }
+        gpio_set_level(static_cast<gpio_num_t>(colPins_[i]), 1);
+    }
+
+    for (size_t i = 0; i < numRows_; ++i) {
+        gpio_config_t rowCfg = {};
+        rowCfg.pin_bit_mask = (1ULL << rowPins_[i]);
+        rowCfg.mode = GPIO_MODE_INPUT;
+        rowCfg.pull_up_en = GPIO_PULLUP_ENABLE;
+        rowCfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+        rowCfg.intr_type = GPIO_INTR_DISABLE;
+        esp_err_t err = gpio_config(&rowCfg);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "failed to config row pin %u: %s", static_cast<unsigned>(rowPins_[i]), esp_err_to_name(err));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void KeypadIO::tick() {
+    for (size_t c = 0; c < numCols_; ++c) {
+        gpio_set_level(static_cast<gpio_num_t>(colPins_[c]), 0);
+        esp_rom_delay_us(SETTLING_DELAY_US);
+
+        for (size_t r = 0; r < numRows_; ++r) {
+            const size_t index = r * numCols_ + c;
+            const bool pressed = gpio_get_level(static_cast<gpio_num_t>(rowPins_[r])) == 0;
+            uint8_t currentState = keyStates_[index];
+
+            currentState &= static_cast<uint8_t>(~(STATE_JUST_PRESSED | STATE_JUST_RELEASED));
+            if (pressed && !(currentState & STATE_PRESSED)) {
+                currentState |= static_cast<uint8_t>(STATE_PRESSED | STATE_JUST_PRESSED);
+                keypadEvent event = {};
+                event.bit.EVENT = KEY_JUST_PRESSED;
+                event.bit.KEY = keymap_[index];
+                event.bit.ROW = r;
+                event.bit.COL = c;
+                pushEvent(event);
+            } else if (!pressed && (currentState & STATE_PRESSED)) {
+                currentState &= static_cast<uint8_t>(~STATE_PRESSED);
+                currentState |= STATE_JUST_RELEASED;
+                keypadEvent event = {};
+                event.bit.EVENT = KEY_JUST_RELEASED;
+                event.bit.KEY = keymap_[index];
+                event.bit.ROW = r;
+                event.bit.COL = c;
+                pushEvent(event);
+            }
+
+            keyStates_[index] = currentState;
+        }
+
+        gpio_set_level(static_cast<gpio_num_t>(colPins_[c]), 1);
+    }
+}
+
+bool KeypadIO::justPressed(uint8_t key, bool clear) {
+    int index = findKeyIndex(key);
+    if (index < 0) {
+        return false;
+    }
+
+    bool pressed = (keyStates_[index] & STATE_JUST_PRESSED) != 0;
+    if (clear) {
+        keyStates_[index] &= static_cast<uint8_t>(~STATE_JUST_PRESSED);
+    }
+    return pressed;
+}
+
+bool KeypadIO::justReleased(uint8_t key) {
+    int index = findKeyIndex(key);
+    if (index < 0) {
+        return false;
+    }
+
+    bool released = (keyStates_[index] & STATE_JUST_RELEASED) != 0;
+    keyStates_[index] &= static_cast<uint8_t>(~STATE_JUST_RELEASED);
+    return released;
+}
+
+bool KeypadIO::isPressed(uint8_t key) const {
+    int index = findKeyIndex(key);
+    if (index < 0) {
+        return false;
+    }
+    return (keyStates_[index] & STATE_PRESSED) != 0;
+}
+
+bool KeypadIO::isReleased(uint8_t key) const {
+    return !isPressed(key);
+}
+
+int KeypadIO::available() const {
+    return static_cast<int>(count_);
+}
+
+keypadEvent KeypadIO::read() {
+    keypadEvent event = {};
+    if (count_ == 0) {
+        return event;
+    }
+
+    event = buffer_[tail_];
+    tail_ = (tail_ + 1) % BUFFER_SIZE;
+    --count_;
+    return event;
+}
+
+void KeypadIO::clear() {
+    head_ = 0;
+    tail_ = 0;
+    count_ = 0;
+    memset(keyStates_, 0, sizeof(keyStates_));
+}
+
+void KeypadIO::pushEvent(const keypadEvent &event) {
+    if (count_ >= BUFFER_SIZE) {
+        tail_ = (tail_ + 1) % BUFFER_SIZE;
+        --count_;
+    }
+
+    buffer_[head_] = event;
+    head_ = (head_ + 1) % BUFFER_SIZE;
+    ++count_;
+}
+
+int KeypadIO::findKeyIndex(uint8_t key) const {
+    for (size_t i = 0; i < numRows_ * numCols_; ++i) {
+        if (keymap_[i] == key) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,5 +1,4 @@
-#include <Arduino.h>
-#include <Adafruit_Keypad.h>
+#include "keypad_io.h"
 #include <MPR121_Keypad.h>
 #include <gfx_oled_ssd1306.h>
 #include <driver/i2s_std.h>
@@ -41,10 +40,13 @@ TaskHandle_t GUI_TASK = NULL;
 USBMIDI MIDI;
 esp_lcd_panel_handle_t panel;
 GfxOledSSD1306 display(DISPLAY_WIDTH, DISPLAY_HEIGHT);
-Adafruit_Keypad keypad = Adafruit_Keypad(makeKeymap(KEYPAD_MAP),
-                                        (uint8_t[KEYPAD_ROWS]){KEYPAD_R0, KEYPAD_R1, KEYPAD_R2, KEYPAD_R3},
-                                        (uint8_t[KEYPAD_COLS]){KEYPAD_C0, KEYPAD_C1, KEYPAD_C2},
-                                        KEYPAD_ROWS, KEYPAD_COLS);
+static const uint8_t kKeypadRows[KEYPAD_ROWS] = {KEYPAD_R0, KEYPAD_R1, KEYPAD_R2, KEYPAD_R3};
+static const uint8_t kKeypadCols[KEYPAD_COLS] = {KEYPAD_C0, KEYPAD_C1, KEYPAD_C2};
+KeypadIO keypad(reinterpret_cast<const uint8_t *>(KEYPAD_MAP),
+                kKeypadRows,
+                kKeypadCols,
+                KEYPAD_ROWS,
+                KEYPAD_COLS);
 MPR121_Keypad touchKeypad(TOUCHPAD0_ADDRS, TOUCHPAD1_ADDRS);
 
 void sound_task(void *arg) {

--- a/main/usb_msc_mode.cpp
+++ b/main/usb_msc_mode.cpp
@@ -1,6 +1,6 @@
 #include "usb_msc_mode.h"
 #include <gfx_oled_ssd1306.h>
-#include <Adafruit_Keypad.h>
+#include "keypad_io.h"
 #include "esp_log.h"
 #include "esp_partition.h"
 #include "esp_system.h"
@@ -40,7 +40,7 @@ static esp_err_t storage_init_spiflash(wl_handle_t *wl_handle) {
     return wl_mount(data_partition, wl_handle);
 }
 
-extern Adafruit_Keypad keypad;
+extern KeypadIO keypad;
 
 void msc_mode(void) {
     wl_handle_t wl_usbmsc_handle;


### PR DESCRIPTION
### Motivation
- Remove the runtime dependency on the Arduino/Adafruit keypad implementation and provide a native ESP-IDF keypad driver that scans matrix rows/columns and exposes unified key events. 
- Decouple physical keypad input from the Adafruit API so touch and keypad inputs share the same event semantics. 
- Reduce Arduino/Adafruit component requirements in the `main` component to move toward an ESP-IDF-first codebase.

### Description
- Added a new native driver `KeypadIO` with header `main/include/keypad_io.h` and implementation `main/keypad_io.cpp` that scans a diode-multiplexed matrix using `driver/gpio` and queues `KEY_JUST_PRESSED`/`KEY_JUST_RELEASED` events via `keypadEvent`/`keypadEvent.bit` semantics. 
- Replaced runtime usages of `Adafruit_Keypad` in `main/` with `KeypadIO` (instantiated in `main/main.cpp`) and converted extern declarations to `KeypadIO keypad` in GUI/common/boot/USB MSC modules. 
- Updated `MPR121_Keypad` header to include `keypad_io.h` so touch keypad events use the same `KEY_JUST_*` constants and align with the new event type. 
- Updated `main/CMakeLists.txt` to compile `keypad_io.cpp` and removed `Adafruit_Keypad` and `arduino-esp32-lite` from the `main` component `REQUIRES` list.

### Testing
- Ran `idf.py build` in this environment and it failed with `idf.py: command not found` because the ESP-IDF toolchain is not available here. (failure)
- Ran `cmake -S . -B build` and it failed due to missing ESP-IDF `project.cmake` in this environment, so a local configure/build could not be completed. (failure)
- No other automated unit/integration tests were available or executed in this environment; runtime validation should be performed on device with a proper ESP-IDF toolchain and target hardware.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1c37a5e108328a92b463d338e181f)